### PR TITLE
Support preact

### DIFF
--- a/lib/transformComponents.js
+++ b/lib/transformComponents.js
@@ -6,7 +6,20 @@ import wrapRender from './wrapRender';
 export function transformComponentsInNode(node, transformComponent) {
   return traverse(node, {
     ComponentElement(path) {
-      const { type, props } = path.node;
+      const { attributes, type, props } = path.node;
+
+      /**
+      * React and Preact both handle how they store "Children" in a slightly
+      * different way.
+      *
+      * Preact adds them to node.children, while React stores them inside of the attributes object
+      **/
+      if (attributes) {
+          // if attributes exist and it doesnt have children, check to see if
+          // their defined on the node (which will be the case with preact)
+          attributes.children = attributes.children || path.node.children;
+      }
+
       return React.createElement(transformComponent(type), props);
     },
   });


### PR DESCRIPTION
In my own local usages, I found that there was a weird bug when using Preact instead of React. This has to do with how React and Preact manage "children" differently.

I've added a check in this MR that will allow this library to support both preact and React, defaulting to React first. 